### PR TITLE
Don't send invalid data types for modules without a version

### DIFF
--- a/src/Controller/ProbeController.php
+++ b/src/Controller/ProbeController.php
@@ -443,6 +443,10 @@ class ProbeController extends ControllerBase {
         'info' => $systemInfo[$module->getName()],
         'path' => DRUPAL_ROOT . '/' . $module->getPath(),
       ];
+      // Make sure we don't send invalid values for modules with no version.
+      if (is_null($detailedModules[$module->getName()]['info']['version'])) {
+        $detailedModules[$module->getName()]['info']['version'] = '';
+      }
     }
     return $detailedModules;
   }


### PR DESCRIPTION
When you have modules without a version, currently we send NULL as a version, this leads to deprecation notices in PHP 8.1 in xmlrpc_value_get_xml:

Deprecated function: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in xmlrpc_value_get_xml() (line 116 of /app/web/modules/contrib/xmlrpc/xmlrpc.inc)

We should probably sanitise this value before sending it on. 